### PR TITLE
Remove 100ms debounce when editing query

### DIFF
--- a/src/graphiql.tsx
+++ b/src/graphiql.tsx
@@ -1251,7 +1251,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
         editor.setValue(print(mergeAST(ast, this.state.schema)));
     };
 
-    handleEditQuery = debounce(100, (value: string) => {
+    handleEditQuery = (value: string) => {
         const queryFacts = this._updateQueryFacts(
             value,
             this.state.operationName,
@@ -1266,7 +1266,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
         if (this.props.onEditQuery) {
             return this.props.onEditQuery(value, queryFacts?.documentAST);
         }
-    });
+    };
 
     handleCopyQuery = () => {
         const editor = this.getQueryEditor();


### PR DESCRIPTION
Hi guys! I noticed that when you're editing information in the left sidebar, in the QueryExplorer component, there's a debounce of 100ms that makes a bit uncomfortable the input of data into it, as you cannot type two keys in less than 100ms or the keystrokes will get lost.

**With debounce**

https://user-images.githubusercontent.com/2999604/119245945-e5a58e00-bb42-11eb-94a0-f9d2d0232321.mp4

**Without debounce**

https://user-images.githubusercontent.com/2999604/119245949-f0602300-bb42-11eb-8241-ea3973d90877.mp4

The change here is pretty simple, I just removed the debounce in this function to sync the component state at the same time the onEdit prop is called from the QueryExplorer component.

Do you know if there's an issue I may be unaware of and that the debounce was needed?